### PR TITLE
feat: Expand npm run lint to cover all src/*.js files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "start": "node src/index.js",
     "test": "node --test",
-    "type-check": "node --check src/index.js",
-    "lint": "node --check src/index.js"
+    "type-check": "node --check src/index.js src/theme.js src/config.js",
+    "lint": "node --check src/index.js src/theme.js src/config.js"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
Implements GitHub issue #15: Expand npm run lint coverage

## Changes
- package.json (lint and type-check scripts expanded to all src/*.js files)

## Validation
Lint OK (all 3 files), 18 tests passing

Closes #15