### PR TITLE
feat: Landing page - structured ASCII output on npm start

### DIFF
--- a/.devox/ralph/landing-page/prd.json
+++ b/.devox/ralph/landing-page/prd.json
@@ -1,0 +1,51 @@
+{
+  "project": "hello-ai-coding-agent",
+  "branchName": "ralph/landing-page",
+  "prdFile": "prd.md",
+  "description": "Replace bare console.log with a structured ASCII landing page rendered to stdout from main()",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Implementing landing page output",
+      "description": "As an AI agent or developer, I want `npm start` to display a structured landing page so that I immediately understand the project name, purpose, and available commands without reading external docs.",
+      "acceptanceCriteria": [
+        "`npm start` prints a multi-line landing page beginning with a separator line of `=` characters",
+        "Output includes the project name `Hello, AI Coding Agent!` and a brief purpose description",
+        "Output lists all four npm commands: `npm start`, `npm test`, `npm run lint`, `npm run type-check`",
+        "Output includes an 'Extend me' section referencing `src/index.js` and `src/*.test.js`",
+        "Output ends with a closing separator line",
+        "`npm start` exits with code 0",
+        "`npm run lint` passes — `node --check src/index.js` exits 0",
+        "`npm run type-check` passes — exits 0",
+        "No new dependencies added to package.json",
+        "No `require` or `import` introduced (no module system established by this story)",
+        "All logic called from `main()` — no top-level side-effects other than the existing `main()` invocation"
+      ],
+      "technicalNotes": "Modify `src/index.js` (the only source file). Replace the current `console.log('Hello, AI Coding Agent!')` inside `main()` with either: (a) multiple `console.log()` calls, or (b) a single `console.log()` with a template literal. Optionally extract a `renderLandingPage()` helper function declared above `main()` using standard `function` declaration style (matching the existing `main()` pattern at src/index.js:1). Do NOT use `require`/`import`. Do NOT add dependencies.",
+      "dependsOn": [],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Writing landing page tests",
+      "description": "As a developer, I want automated tests for the landing page output so that regressions are caught when `src/index.js` is modified.",
+      "acceptanceCriteria": [
+        "Test file `src/index.test.js` exists and is discovered by `node --test`",
+        "`npm test` exits 0 AND reports at least 1 test executed (not 0 tests)",
+        "Tests assert that the landing page output contains `Hello, AI Coding Agent!`",
+        "Tests assert that the output contains the string `npm test`",
+        "Tests assert that the output contains the string `npm run lint`",
+        "Tests assert that the output contains `src/index.js`",
+        "Tests use only `node:assert` and `node:test` (no external test libraries)",
+        "`npm run lint` passes with both `src/index.js` and `src/index.test.js` present"
+      ],
+      "technicalNotes": "Create `src/index.test.js`. Use Node.js built-in test runner: `import { test } from 'node:test'; import assert from 'node:assert';` — OR CJS equivalent `const { test } = require('node:test'); const assert = require('node:assert');`. IMPORTANT: if this is the first file to introduce `require` or `import`, it sets the module system precedent for the whole repo — choose deliberately. Capture stdout by temporarily replacing `console.log` with a stub, or by extracting `renderLandingPage()` from US-001 so it returns a string that can be tested directly without stdout capture. The simpler approach: if US-001 extracted `renderLandingPage()` that returns a string, import/require it and assert on the return value. File pattern `src/*.test.js` is discovered by `node --test` automatically.",
+      "dependsOn": ["US-001"],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/.devox/ralph/landing-page/prd.md
+++ b/.devox/ralph/landing-page/prd.md
@@ -1,0 +1,129 @@
+# Landing Page — Product Requirements
+
+## Overview
+
+**Problem**: Running `npm start` outputs only `Hello, AI Coding Agent!` — a bare string that gives users (and AI agents arriving at the repo for the first time) no orientation about what the project is, what commands are available, or how to extend it. First contact with the repo is a dead end.
+**Solution**: Replace the bare `console.log` with a structured, multi-line ASCII landing page rendered to stdout — a "welcome screen" that surfaces project identity, available npm commands, and the extend-me invitation — all within the existing `main()` orchestrator and zero new dependencies.
+**Branch**: `ralph/landing-page`
+
+---
+
+## Goals & Success
+
+### Primary Goal
+When a user or AI agent runs `npm start`, they see a self-describing landing page that tells them the project name, its purpose, available commands, and where to start extending it — without reading any external docs.
+
+### Success Metrics
+| Metric | Target | How Measured |
+|--------|--------|--------------|
+| `npm start` exit code | 0 | `echo $?` after run |
+| Landing page renders | All sections visible | Manual / test assertion on stdout |
+| `npm run lint` passes | 0 syntax errors | `node --check src/index.js` |
+| `npm test` discovers and passes tests | ≥ 1 test file executed | `node --test` output |
+
+### Non-Goals (Out of Scope)
+- Interactive menus or prompts — this is a read-only informational display
+- Colour/ANSI escape codes — keep output plain-text for maximum terminal compatibility
+- Reading from a config file or environment variables — all content is hardcoded constants
+- HTTP server, web browser landing page — this is strictly CLI stdout
+
+---
+
+## User & Context
+
+### Target User
+- **Who**: AI coding agents and developers first cloning or running the scaffold
+- **Role**: Experimenter evaluating the repo as a test substrate for AI tooling
+- **Current Pain**: `npm start` outputs a single opaque line with no context; the user must read README/MISSION.md to understand what to do next
+
+### User Journey
+1. **Trigger**: User clones the repo and runs `npm start` (or an AI agent executes the entry point)
+2. **Action**: Node runs `src/index.js`, `main()` is invoked
+3. **Outcome**: A formatted landing page prints to stdout; the user knows the project name, purpose, and the four npm commands available, then exits cleanly with code 0
+
+---
+
+## UX Requirements
+
+### Interaction Model
+Stdout-only CLI output. No stdin, no flags, no prompts. Single invocation: `node src/index.js`.
+
+### Landing Page Content (all sections required)
+```
+========================================
+  Hello, AI Coding Agent!
+  A minimal scaffold for AI experiments
+========================================
+
+  Commands:
+    npm start        Run the application
+    npm test         Run tests (node --test)
+    npm run lint     Syntax check
+    npm run type-check  Syntax check
+
+  Extend me:
+    Add functions to src/index.js
+    Co-locate tests in src/*.test.js
+
+========================================
+```
+
+### States to Handle
+| State | Description | Behavior |
+|-------|-------------|----------|
+| Normal run | Standard `npm start` | Print landing page, exit 0 |
+| No edge cases | Pure stdout, no I/O | N/A — no error states possible |
+
+---
+
+## Technical Context
+
+### Patterns to Follow
+- **Entry point**: `src/index.js` lines 1–5 — all logic lives inside `main()`, invoked at bottom of file
+- **Output**: `console.log()` — established output mechanism; use multiple calls or a single multi-line template literal
+- **Test pattern**: `src/*.test.js` — Node.js built-in `node --test` runner; use `assert` from `node:assert`; no external test libraries
+
+### Types & Interfaces
+```javascript
+// No types in use — plain JavaScript (no TypeScript, no JSDoc required for trivial functions)
+// New helper function signature (optional extraction):
+// function renderLandingPage() { /* returns void, writes to stdout */ }
+```
+
+### Architecture Notes
+- All new logic must be called from `main()` — do not execute at module top level
+- No module system (`require`/`import`) exists yet; do NOT introduce one for this feature — all code stays in `src/index.js`
+- No new dependencies — `console.log` + string literals are sufficient
+- If a `renderLandingPage()` helper is extracted, it must be declared as a named `function` (hoisted declaration style matches existing `main()`)
+- Test file: `src/index.test.js` — use Node.js built-in `node:assert` and `node:test`
+
+---
+
+## Implementation Summary
+
+### Story Overview
+| ID | Title | Priority | Dependencies |
+|----|-------|----------|--------------|
+| US-001 | Implementing landing page output | 1 | — |
+| US-002 | Writing landing page tests | 2 | US-001 |
+
+### Dependency Graph
+```
+US-001 (landing page implementation)
+    ↓
+US-002 (tests)
+```
+
+---
+
+## Validation Requirements
+
+Every story must pass:
+- [ ] Lint: `npm run lint` (node --check src/index.js) exits 0
+- [ ] Type-check: `npm run type-check` exits 0
+- [ ] Tests: `npm test` exits 0 AND discovers ≥ 1 test file
+- [ ] Start: `npm start` prints the landing page and exits 0
+
+---
+
+*Generated: 2026-06-04T15:01:28.792+02:00*

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,27 @@
+function renderLandingPage() {
+  var sep = '========================================';
+  return [
+    sep,
+    '  Hello, AI Coding Agent!',
+    '  A minimal scaffold for AI experiments',
+    sep,
+    '',
+    '  Commands:',
+    '    npm start           Run the application',
+    '    npm test            Run tests (node --test)',
+    '    npm run lint        Syntax check',
+    '    npm run type-check  Syntax check',
+    '',
+    '  Extend me:',
+    '    Add functions to src/index.js',
+    '    Co-locate tests in src/*.test.js',
+    '',
+    sep,
+  ].join('\n');
+}
+
 function main() {
-  console.log('Hello, AI Coding Agent!');
+  console.log(renderLandingPage());
 }
 
 main();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,23 @@
+var test = require('node:test');
+var assert = require('node:assert');
+var child_process = require('node:child_process');
+
+test('landing page contains project name', function () {
+  var result = child_process.spawnSync(process.execPath, ['src/index.js'], { encoding: 'utf8' });
+  assert.ok(result.stdout.includes('Hello, AI Coding Agent!'));
+});
+
+test('landing page contains npm test command', function () {
+  var result = child_process.spawnSync(process.execPath, ['src/index.js'], { encoding: 'utf8' });
+  assert.ok(result.stdout.includes('npm test'));
+});
+
+test('landing page contains npm run lint command', function () {
+  var result = child_process.spawnSync(process.execPath, ['src/index.js'], { encoding: 'utf8' });
+  assert.ok(result.stdout.includes('npm run lint'));
+});
+
+test('landing page contains src/index.js reference', function () {
+  var result = child_process.spawnSync(process.execPath, ['src/index.js'], { encoding: 'utf8' });
+  assert.ok(result.stdout.includes('src/index.js'));
+});


### PR DESCRIPTION
﻿## Summary

Replaces the bare console.log with a structured, multi-line ASCII landing page rendered to stdout. Users and AI agents running `npm start` now immediately see the project name, purpose, all four available npm commands, and where to start extending the project.

## Stories

| ID | Title | Status |
|----|-------|--------|
| US-001 | Implementing landing page output | PASSED |
| US-002 | Writing landing page tests | PASSED |

## Changes

- src/index.js: Added renderLandingPage() helper that returns the full landing page as a string. main() calls console.log(renderLandingPage()). No module system introduced in index.js; no new dependencies.
- src/index.test.js: New test file with 4 tests using node:test and node:assert. Tests capture stdout via node:child_process and assert the landing page contains expected content.

## Validation

- npm run lint: exit 0
- npm run type-check: exit 0
- npm test: 4/4 tests pass, exit 0
- npm start: landing page renders, exit 0

## Architecture Notes

- CJS (require) established as the module system precedent (introduced by test file)
- renderLandingPage() returns a string to enable direct string assertion in future tests
- No ANSI/colour codes - plain-text output for maximum terminal compatibility
- Zero new runtime or dev dependencies added
