### PR TITLE
docs: add Web / PWA Mode section to ReadMe.md (FR-10)

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-# Hello AI Coding Agent
+﻿# Hello AI Coding Agent
 
 A minimal scaffold for experimenting with AI-assisted coding agents.
 
@@ -26,3 +26,37 @@ npm test
 2. Create a feature branch (`git checkout -b feature/my-change`)
 3. Commit your changes with a clear message
 4. Open a pull request against `main`
+
+## Web / PWA Mode
+
+Start the local development server:
+
+```bash
+npm run serve
+```
+
+The app is served at **http://localhost:3000**.
+
+### HTTPS Requirement
+
+Service workers require a secure context (`https://`). For local development, `localhost` is exempt — the service worker will register and offline mode will function on `http://localhost:3000`. In production, the app must be served over `https://`.
+
+### Offline Capability
+
+Once the service worker is installed (on first visit), the app shell and cached assets are available offline. Subsequent loads do not require a network connection.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3000` | Port the development server listens on |
+
+Copy `.env.example` to `.env` and adjust as needed:
+
+```bash
+cp .env.example .env
+```
+
+### Known Limitations
+
+`npm run lint` covers `src/` only. JavaScript files under `public/` are **not** checked by the linter. Review those files manually.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-﻿# Hello AI Coding Agent
+# Hello AI Coding Agent
 
 A minimal scaffold for experimenting with AI-assisted coding agents.
 
@@ -26,6 +26,10 @@ npm test
 2. Create a feature branch (`git checkout -b feature/my-change`)
 3. Commit your changes with a clear message
 4. Open a pull request against `main`
+
+> **Prerequisites**: This section documents features on the `feature/progressive-web-app` branch.
+> Until that branch is merged, `npm run serve`, `.env.example`, and the `public/` directory
+> do not exist on `main`. Do not follow these instructions on `main`.
 
 ## Web / PWA Mode
 
@@ -59,4 +63,4 @@ cp .env.example .env
 
 ### Known Limitations
 
-`npm run lint` covers `src/` only. JavaScript files under `public/` are **not** checked by the linter. Review those files manually.
+`npm run lint` (`node --check src/index.js`) checks only `src/index.js` — it is not a directory scan. It is also **not an ES5 compliance gate** (it accepts all ES2022+ syntax silently). JavaScript files under `public/` are not linted; review them manually.


### PR DESCRIPTION
## Summary

Adds a `Web / PWA Mode` section to `ReadMe.md` documenting the PWA capability. Documentation-only change - no source code, scripts, or dependencies modified.

## Changes

- **`ReadMe.md`**: Appended a new `## Web / PWA Mode` section after `## Contributing` (+35 lines). No existing section modified.

The new section documents:
- `npm run serve` start command and access URL (http://localhost:3000)
- HTTPS production constraint + localhost exemption for service workers
- Offline capability summary (service worker caching)
- `PORT` environment variable with .env.example reference
- Known lint gap: public/ JS files are not covered by npm run lint

## Validation

| Check | Result |
|-------|--------|
| npm run lint | Exit 0 |
| node src/index.js stdout | Hello, AI Coding Agent! (byte-exact) |
| Web / PWA Mode section present | Match found at line 30 |
| git diff - additions only | No existing lines modified |

## Notes

This PR depends on the feature/progressive-web-app branch containing a working npm run serve script and a public/ directory before merge.

Fixes #38