### PR TITLE
feat: Add static planets reference page

### DIFF
--- a/.devox/ralph/statics-page-planets/prd.json
+++ b/.devox/ralph/statics-page-planets/prd.json
@@ -1,0 +1,90 @@
+{
+  "project": "hello-ai-coding-agent",
+  "branchName": "ralph/statics-page-planets",
+  "prdFile": "prd.md",
+  "description": "Add a self-contained static HTML page listing all 8 planets of our solar system, openable via file:// with no server or new dependencies.",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Create public/ directory and base HTML skeleton",
+      "description": "As a developer cloning the repo, I want a public/ directory with a valid HTML5 skeleton at public/planets.html so that I have a foundation for the planets reference page.",
+      "acceptanceCriteria": [
+        "Directory public/ exists at the repository root",
+        "File public/planets.html exists and is a valid HTML5 document (DOCTYPE, html, head, body tags present)",
+        "The file has a <title> tag containing 'Planets Around Us'",
+        "The file ends with a trailing newline",
+        "src/index.js is not modified in any way",
+        "npm run lint exits 0 (node --check src/index.js)",
+        "node src/index.js outputs exactly: Hello, AI Coding Agent! followed by a newline",
+        "No package-lock.json is generated"
+      ],
+      "technicalNotes": "Create public/planets.html with a standard HTML5 boilerplate. No <script> tags. No external resources. All future CSS goes in a <style> block in <head>. Follow the trailing-newline convention from CLAUDE.md (all files must end with a newline). Do not touch src/index.js.",
+      "dependsOn": [],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Add planet data markup for all 8 planets",
+      "description": "As a user opening the planets page, I want to see a card or section for each of the 8 planets ordered by distance from the Sun, so that I can read factual information about each one.",
+      "acceptanceCriteria": [
+        "All 8 planets present: Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune",
+        "Planets appear in order of distance from the Sun (Mercury first, Neptune last)",
+        "Each planet section includes: name, classification (Terrestrial / Gas Giant / Ice Giant), diameter in km, mean distance from Sun in AU, and a 2-3 sentence description",
+        "Data is encoded as semantic HTML (e.g. <article>, <h2>, <dl>/<dt>/<dd> or equivalent)",
+        "No <script> tags added",
+        "No external CDN or font resources linked",
+        "src/index.js is not modified",
+        "npm run lint exits 0",
+        "node src/index.js outputs byte-exact oracle string"
+      ],
+      "technicalNotes": "Add planet cards inside the <body> of public/planets.html created in US-001. Encode data as static HTML — no JavaScript arrays or template generation. Use <article class='planet-card' id='{planet-name}'> with an <h2> for the name and a <dl> for structured data. Planet facts to use: Mercury (Terrestrial, 4,879 km, 0.39 AU), Venus (Terrestrial, 12,104 km, 0.72 AU), Earth (Terrestrial, 12,742 km, 1.00 AU), Mars (Terrestrial, 6,779 km, 1.52 AU), Jupiter (Gas Giant, 139,820 km, 5.20 AU), Saturn (Gas Giant, 116,460 km, 9.58 AU), Uranus (Ice Giant, 50,724 km, 19.22 AU), Neptune (Ice Giant, 49,244 km, 30.05 AU).",
+      "dependsOn": ["US-001"],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Add embedded CSS for layout and readability",
+      "description": "As a user viewing the planets page in a browser, I want the page to be readable and visually organised so that planet information is easy to scan.",
+      "acceptanceCriteria": [
+        "All CSS is inside a single <style> block in the <head> of public/planets.html",
+        "No external stylesheet links, no CDN font imports",
+        "Planet cards are displayed in a responsive grid (2+ columns on wide screens, 1 column on narrow screens via CSS media query)",
+        "Body uses a legible system font stack (e.g. system-ui, sans-serif) — no @import or external font",
+        "Page is readable on a viewport as narrow as 320px",
+        "Page heading 'Planets Around Us — Our Solar System' is present and styled as <h1>",
+        "No <script> tags added",
+        "src/index.js is not modified",
+        "npm run lint exits 0",
+        "node src/index.js outputs byte-exact oracle string"
+      ],
+      "technicalNotes": "Add a <style> block in <head> of public/planets.html. Use CSS Grid for the card layout: `display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem;`. Use a system font stack. Add a @media print rule with `background: white; color: black` to avoid ink waste. No JavaScript. No external dependencies.",
+      "dependsOn": ["US-001"],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "Update README.md to document the planets page",
+      "description": "As a developer reading the repository README, I want to know that public/planets.html exists and how to open it, so that I can discover the planets page without guessing.",
+      "acceptanceCriteria": [
+        "README.md contains a new section titled '## Planets Reference Page' (or equivalent)",
+        "Section explains that public/planets.html can be opened directly in a browser via the file:// protocol",
+        "Section includes the exact command to open it on each major OS (e.g. `start public/planets.html` on Windows, `open public/planets.html` on macOS)",
+        "No other sections of README.md are modified beyond adding the new section",
+        "src/index.js is not modified",
+        "npm run lint exits 0",
+        "node src/index.js outputs byte-exact oracle string"
+      ],
+      "technicalNotes": "Edit README.md (the only mutable human-facing doc per GUARDRAILS.md). Add the new section after the existing 'Running Tests' section. Keep prose minimal. Reference public/planets.html by its path relative to the repo root.",
+      "dependsOn": ["US-001", "US-002", "US-003"],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/.devox/ralph/statics-page-planets/prd.md
+++ b/.devox/ralph/statics-page-planets/prd.md
@@ -1,0 +1,140 @@
+# Statics Page — Planets Around Us — Product Requirements
+
+## Overview
+
+**Problem**: The repository has no human-readable reference content beyond governance documents. Users cloning the project have no visual artefact to look at beyond the CLI oracle string. A self-contained planets reference page demonstrates that the project _can_ ship a deliverable without violating any of its hard invariants.
+**Solution**: A fully static, server-free HTML file (`public/planets.html`) that renders an informational reference page about the eight planets of our solar system. The file opens directly in any browser — no HTTP server, no Node.js changes, no new dependencies.
+**Branch**: `ralph/statics-page-planets`
+
+---
+
+## Goals & Success
+
+### Primary Goal
+Deliver a single, self-contained `public/planets.html` file that displays factual information about the planets in our solar system and can be opened in any modern browser without a server.
+
+### Success Metrics
+| Metric | Target | How Measured |
+|--------|--------|--------------|
+| Planet coverage | All 8 planets present | Count `<section>` or data cards in rendered HTML |
+| Server-free | Opens via `file://` protocol | Open with `start public/planets.html` — no server |
+| Zero JS dependency | No `<script>` tags referencing npm packages | Manual inspection of HTML source |
+| `src/index.js` unchanged | Stdout oracle still `Hello, AI Coding Agent!\n` | `node src/index.js` byte-verify |
+
+### Non-Goals (Out of Scope)
+- HTTP server or `npm start`-served page — would require modifying `package.json` scripts (hard invariant)
+- A second `.js` file under `src/` — permanently prohibited by MISSION.md
+- npm package dependencies for templating or a static site generator — zero-dep invariant
+- Dynamic data fetching (API calls, `fetch()`) — no async I/O allowed in the project runtime
+- Modifying `src/index.js` in any way — the oracle string is frozen and single-file architecture is permanent
+- Modifying any governance file (`MISSION.md`, `GUARDRAILS.md`, `CLAUDE.md`, `AGENTS.md`)
+
+---
+
+## User & Context
+
+### Target User
+- **Who**: Developer or researcher who has cloned the `hello-ai-coding-agent` governance benchmark
+- **Role**: AI platform calibration engineer, AI safety researcher, or DevEx engineer evaluating agent behaviour
+- **Current Pain**: The repository ships only a CLI oracle and governance docs — no visual reference artefact demonstrates that a non-JS deliverable can coexist with the strict governance rules
+
+### User Journey
+1. **Trigger**: User wants a visual page after cloning the repo, or an agent task asks "add informational content about planets"
+2. **Action**: User opens `public/planets.html` in their browser (double-click or `start public/planets.html` on Windows)
+3. **Outcome**: A well-structured, readable page listing all 8 planets with name, type, diameter, distance from the Sun, and a short description is displayed
+
+---
+
+## UX Requirements
+
+### Interaction Model
+Static file opened directly via `file://` in a browser. No CLI commands, no server, no build step.
+The page is self-contained: all CSS is inline or in a `<style>` block within the same HTML file.
+
+### States to Handle
+| State | Description | Behavior |
+|-------|-------------|----------|
+| Normal | Browser opens file | Full page renders with all 8 planets |
+| No images | Images absent or blocked | Page text and data are fully readable without images |
+| Narrow viewport | Mobile/small screen | Planet cards reflow to single-column layout via CSS media query |
+| Print | User prints page | White background, no decorative colours that waste ink |
+
+### Visual Requirements
+- Heading: "Planets Around Us — Our Solar System"
+- One card per planet, showing: name, classification (terrestrial/gas giant/ice giant), diameter (km), mean distance from Sun (AU), and a 2–3 sentence description
+- Planets ordered by distance from the Sun: Mercury → Venus → Earth → Mars → Jupiter → Saturn → Uranus → Neptune
+- Light background with readable font; no external fonts or CDN resources (self-contained)
+- Responsive layout with CSS Grid or Flexbox
+
+---
+
+## Technical Context
+
+### Patterns to Follow
+- **Runtime oracle**: `src/index.js` lines 1–5 — do **not** modify; only add new files
+- **Zero-dep convention**: `package.json` — no `<script src="...">` from npm or CDN
+- **File placement**: new file lives under `public/` (a new directory — not `src/`) — no prohibition on directories other than `src/`
+- **Trailing newline**: all files must end with a trailing newline (CLAUDE.md convention)
+
+### Types & Interfaces
+No JavaScript types are required. Planet data is encoded as static HTML markup:
+
+```html
+<!-- Data model per planet card -->
+<article class="planet-card" id="earth">
+  <h2>Earth</h2>
+  <dl>
+    <dt>Type</dt><dd>Terrestrial</dd>
+    <dt>Diameter</dt><dd>12,742 km</dd>
+    <dt>Distance from Sun</dt><dd>1.00 AU</dd>
+    <dt>Description</dt><dd>...</dd>
+  </dl>
+</article>
+```
+
+### Architecture Notes
+- Deliverable is `public/planets.html` — a single file, no directory nesting beyond `public/`
+- No `<script>` tags at all; pure HTML + CSS
+- CSS is embedded in a `<style>` block inside `<head>` — no external stylesheet
+- `README.md` updated in a follow-on story to mention the new file
+- `src/index.js` is **not touched** — the oracle string remains `Hello, AI Coding Agent!\n`
+- The `.gitignore` is not modified (no new exclusion needed for HTML files)
+- Validation: `node src/index.js` byte-verify and `npm run lint` must still pass after adding the file
+
+---
+
+## Implementation Summary
+
+### Story Overview
+| ID | Title | Priority | Dependencies |
+|----|-------|----------|--------------|
+| US-001 | Create `public/` directory and base HTML skeleton | 1 | — |
+| US-002 | Add planet data section with all 8 planets | 2 | US-001 |
+| US-003 | Add embedded CSS for layout and readability | 3 | US-001 |
+| US-004 | Update README.md to document the planets page | 4 | US-001, US-002, US-003 |
+
+### Dependency Graph
+```
+US-001 (HTML skeleton + public/ dir)
+    ↓
+US-002 (planet data markup)   US-003 (embedded CSS)
+    ↓                              ↓
+              US-004 (README update)
+```
+
+---
+
+## Validation Requirements
+
+Every story must pass:
+- [ ] Lint: `npm run lint` (`node --check src/index.js`) exits 0 — src/index.js must be untouched
+- [ ] Type-check: `npm run type-check` exits 0 — byte-identical to lint
+- [ ] Tests: `npm test` exits 0 (currently silent pass — do not introduce test regressions)
+- [ ] Stdout oracle: `node src/index.js` → byte-exact `Hello, AI Coding Agent!\n`
+- [ ] No `package-lock.json` generated
+- [ ] `public/planets.html` opens in browser via `file://` without a server
+- [ ] All 8 planets present and ordered by distance from the Sun
+
+---
+
+*Generated: 2026-07-10T09:16:57+02:00*

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,6 +20,25 @@ npm start
 npm test
 ```
 
+## Planets Reference Page
+
+A self-contained static HTML page listing all 8 planets of our solar system is available at `public/planets.html`. Open it directly in any browser — no server required.
+
+**Windows:**
+```
+start public/planets.html
+```
+
+**macOS:**
+```
+open public/planets.html
+```
+
+**Linux:**
+```
+xdg-open public/planets.html
+```
+
 ## Contributing
 
 1. Fork the repository

--- a/public/planets.html
+++ b/public/planets.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Planets Around Us</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #0d1117;
+      color: #e6edf3;
+      margin: 0;
+      padding: 1.5rem;
+      line-height: 1.6;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+
+    h1 {
+      font-size: 2rem;
+      margin: 0 0 0.5rem;
+      color: #f0f6fc;
+    }
+
+    header p {
+      color: #8b949e;
+      margin: 0;
+    }
+
+    .planets-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1.5rem;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    .planet-card {
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      padding: 1.25rem;
+    }
+
+    .planet-card h2 {
+      margin: 0 0 0.75rem;
+      font-size: 1.25rem;
+      color: #79c0ff;
+    }
+
+    dl {
+      margin: 0;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 0.25rem 1rem;
+    }
+
+    dt {
+      color: #8b949e;
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding-top: 0.1rem;
+    }
+
+    dd {
+      margin: 0;
+      color: #e6edf3;
+    }
+
+    dd.description {
+      grid-column: 1 / -1;
+      margin-top: 0.5rem;
+      color: #c9d1d9;
+      font-size: 0.95rem;
+    }
+
+    .badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      padding: 0.15rem 0.5rem;
+      border-radius: 12px;
+      font-weight: 600;
+    }
+
+    .badge-terrestrial { background: #1f3a2a; color: #56d364; }
+    .badge-gas-giant   { background: #2d2a1f; color: #e3b341; }
+    .badge-ice-giant   { background: #1f2d3a; color: #58a6ff; }
+
+    @media (max-width: 320px) {
+      body { padding: 0.75rem; }
+      h1 { font-size: 1.4rem; }
+      dl { grid-template-columns: 1fr; }
+      dt { margin-top: 0.4rem; }
+    }
+
+    @media print {
+      body { background: white; color: black; padding: 0; }
+      .planet-card { background: white; border-color: #ccc; }
+      .planet-card h2 { color: black; }
+      dt { color: #555; }
+      dd { color: black; }
+      dd.description { color: #333; }
+      .badge-terrestrial { background: #d4edda; color: #155724; }
+      .badge-gas-giant   { background: #fff3cd; color: #856404; }
+      .badge-ice-giant   { background: #cce5ff; color: #004085; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Planets Around Us — Our Solar System</h1>
+    <p>Eight planets ordered by distance from the Sun</p>
+  </header>
+
+  <div class="planets-grid">
+
+    <article class="planet-card" id="mercury">
+      <h2>Mercury</h2>
+      <dl>
+        <dt>Type</dt>
+        <dd><span class="badge badge-terrestrial">Terrestrial</span></dd>
+        <dt>Diameter</dt>
+        <dd>4,879 km</dd>
+        <dt>Distance from Sun</dt>
+        <dd>0.39 AU</dd>
+        <dd class="description">Mercury is the smallest planet in the Solar System and the closest to the Sun.
+          It has no atmosphere to retain heat, causing extreme temperature swings from
+          430 °C during the day to −180 °C at night.</dd>
+      </dl>
+    </article>
+
+    <article class="planet-card" id="venus">
+      <h2>Venus</h2>
+      <dl>
+        <dt>Type</dt>
+        <dd><span class="badge badge-terrestrial">Terrestrial</span></dd>
+        <dt>Diameter</dt>
+        <dd>12,104 km</dd>
+        <dt>Distance from Sun</dt>
+        <dd>0.72 AU</dd>
+        <dd class="description">Venus is the second planet from the Sun and the hottest in the Solar System,
+          with surface temperatures around 465 °C due to a thick carbon-dioxide atmosphere.
+          It rotates very slowly and in the opposite direction to most planets.</dd>
+      </dl>
+    </article>
+
+    <article class="planet-card" id="earth">
+      <h2>Earth</h2>
+      <dl>
+        <dt>Type</dt>
+        <dd><span class="badge badge-terrestrial">Terrestrial</span></dd>
+        <dt>Diameter</dt>
+        <dd>12,742 km</dd>
+        <dt>Distance from Sun</dt>
+        <dd>1.00 AU</dd>
+        <dd class="description">Earth is the third planet from the Sun and the only known planet to harbour life.
+          It has liquid water on its surface, a protective magnetic field, and an oxygen-rich
+          atmosphere that sustains a vast diversity of organisms.</dd>
+      </dl>
+    </article>
+
+    <article class="planet-card" id="mars">
+      <h2>Mars</h2>
+      <dl>
+        <dt>Type</dt>
+        <dd><span class="badge badge-terrestrial">Terrestrial</span></dd>
+        <dt>Diameter</dt>
+        <dd>6,779 km</dd>
+        <dt>Distance from Sun</dt>
+        <dd>1.52 AU</dd>
+        <dd class="description">Mars is the fourth planet from the Sun, known as the Red Planet due to
+          iron-oxide dust covering its surface. It hosts Olympus Mons, the tallest volcano
+          in the Solar System, and is the most explored planet beyond Earth.</dd>
+      </dl>
+    </article>
+
+    <article class="planet-card" id="jupiter">
+      <h2>Jupiter</h2>
+      <dl>
+        <dt>Type</dt>
+        <dd><span class="badge badge-gas-giant">Gas Giant</span></dd>
+        <dt>Diameter</dt>
+        <dd>139,820 km</dd>
+        <dt>Distance from Sun</dt>
+        <dd>5.20 AU</dd>
+        <dd class="description">Jupiter is the largest planet in the Solar System, more than twice as massive
+          as all other planets combined. Its Great Red Spot is a storm that has raged for
+          centuries, and it has at least 95 known moons.</dd>
+      </dl>
+    </article>
+
+    <article class="planet-card" id="saturn">
+      <h2>Saturn</h2>
+      <dl>
+        <dt>Type</dt>
+        <dd><span class="badge badge-gas-giant">Gas Giant</span></dd>
+        <dt>Diameter</dt>
+        <dd>116,460 km</dd>
+        <dt>Distance from Sun</dt>
+        <dd>9.58 AU</dd>
+        <dd class="description">Saturn is the sixth planet from the Sun and is famous for its stunning ring
+          system made of ice and rock. It is the least dense planet — it would float on
+          water — and has 146 known moons, including the large Titan.</dd>
+      </dl>
+    </article>
+
+    <article class="planet-card" id="uranus">
+      <h2>Uranus</h2>
+      <dl>
+        <dt>Type</dt>
+        <dd><span class="badge badge-ice-giant">Ice Giant</span></dd>
+        <dt>Diameter</dt>
+        <dd>50,724 km</dd>
+        <dt>Distance from Sun</dt>
+        <dd>19.22 AU</dd>
+        <dd class="description">Uranus is the seventh planet from the Sun and rotates on its side, with an
+          axial tilt of 98°. It is an ice giant composed mainly of water, methane, and
+          ammonia ices, giving it a pale blue-green colour.</dd>
+      </dl>
+    </article>
+
+    <article class="planet-card" id="neptune">
+      <h2>Neptune</h2>
+      <dl>
+        <dt>Type</dt>
+        <dd><span class="badge badge-ice-giant">Ice Giant</span></dd>
+        <dt>Diameter</dt>
+        <dd>49,244 km</dd>
+        <dt>Distance from Sun</dt>
+        <dd>30.05 AU</dd>
+        <dd class="description">Neptune is the eighth and farthest planet from the Sun. It has the strongest
+          winds in the Solar System, reaching over 2,100 km/h, and its largest moon Triton
+          orbits in the opposite direction to Neptune's rotation.</dd>
+      </dl>
+    </article>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a self-contained static HTML planets reference page (public/planets.html) that opens directly in any browser via ile:// — no server, no new dependencies, no changes to the runtime oracle.

## What Changed

| File | Change |
|------|--------|
| public/planets.html | New file: HTML5 page with all 8 planets, embedded CSS grid layout, print styles |
| ReadMe.md | Added ## Planets Reference Page section with OS-specific open commands |

## Stories Implemented

| ID | Title | Status |
|----|-------|--------|
| US-001 | Create public/ directory and base HTML skeleton | ✅ |
| US-002 | Add planet data markup for all 8 planets | ✅ |
| US-003 | Add embedded CSS for layout and readability | ✅ |
| US-004 | Update README.md to document the planets page | ✅ |

## Validation Evidence

- 
pm run lint — exits 0 (node --check src/index.js)
- 
pm run type-check — exits 0
- 
pm test — exits 0
- 
ode src/index.js — outputs exactly: Hello, AI Coding Agent!
- src/index.js — not modified; stdout oracle unchanged
- No package-lock.json generated

## Architecture

- Pure HTML5 + embedded <style> block — zero JavaScript, zero external resources
- CSS Grid with uto-fit minmax(280px, 1fr) for responsive layout
- System font stack — no CDN or @import
- @media print rule for ink-safe printing
- Semantic markup: <article class=planet-card> + <dl>/<dt>/<dd> per planet

## Security

No scripts, no fetch, no network — static file only. No new attack surface.

## Compatibility

Opens in any modern browser via ile://. Readable at 320px viewport width.

## Rollback

Delete public/planets.html and revert ReadMe.md section.